### PR TITLE
This package is needed for the WebSocket example to work properly.

### DIFF
--- a/chapter8/auction/client/jsconfig.json
+++ b/chapter8/auction/client/jsconfig.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "target": "ES6"
-  }
-}

--- a/chapter8/http_websocket_samples/package.json
+++ b/chapter8/http_websocket_samples/package.json
@@ -28,6 +28,7 @@
     "@types/express": "^4.0.31",
     "@types/node": "^4.0.30",
     "express": "^4.14.0",
+    "reflect-metadata": "^0.1.9",
     "ws": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Without this package, it seems the code samples don't work. The browser reports the following errors:

```
GET http://localhost:8000/node_modules/reflect-metadata/Reflect.js 
localhost/:10 GET http://localhost:8000/node_modules/reflect-metadata/Reflect.js 404 (Not Found)
(index):15 Error: (SystemJS) reflect-metadata shim is required when using class decorators
Error loading http://localhost:8000/app/websocket-observable-service-subscriber.ts
```