### PR TITLE
jsconfig.json in client dir messes up VSCode.

### DIFF
--- a/chapter8/auction/client/jsconfig.json
+++ b/chapter8/auction/client/jsconfig.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "target": "ES6"
-  }
-}


### PR DESCRIPTION
Removing jsconfig.json file from the client directory as it's interfering with tsconfig.json in the root directory. This messes up VSCode, not allowing it to resolve dependencies properly. npm scripts are unaffected by this.