### PR TITLE
Remove extraneous argument for passwordsGroup FormGroup

### DIFF
--- a/chapter7/form-samples/app/09_reactive-with-validation.ts
+++ b/chapter7/form-samples/app/09_reactive-with-validation.ts
@@ -67,7 +67,7 @@ class AppComponent {
       'passwordsGroup': new FormGroup({
         'password': new FormControl('', Validators.minLength(5)),
         'pconfirm': new FormControl('')
-      }, {}, equalValidator)
+      }, equalValidator)
     });
   }
 


### PR DESCRIPTION
When running Ch 7's ```09_reactive-with-validation.ts``` the following is shown in the developer console:

```
EXCEPTION: Error in :0:0 caused by: this.validator is not a function
ErrorHandler.handleError @ :62683/node_modules/@angular/core/bundles/core.umd.min.js:31
```

The root cause appears to be in the constructor for ```passwordsGroup```, where an object literal is used as the second argument for the constructor, and ```equalValidator``` is used as the async validator argument.  Removing the second argument (making ```equalValidator``` the second/synchronous validator argument) resolves this issue